### PR TITLE
Polish splash loading and error screens

### DIFF
--- a/presentation/src/main/java/com/example/presentation/splash/screen/ErrorScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/splash/screen/ErrorScreen.kt
@@ -1,29 +1,59 @@
 package com.example.presentation.splash.screen
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
-import androidx.compose.material3.Button
+import androidx.compose.foundation.layout.size
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.Error
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.unit.dp
+import com.example.presentation.common.component.LargeButton
+import com.example.presentation.common.theme.GradientNavy
+import com.example.presentation.common.theme.Paddings
 
 @Composable
 fun ErrorScreen(message: String, onRetry: () -> Unit) {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        GradientNavy.copy(alpha = 0f),
+                        GradientNavy.copy(alpha = 1f)
+                    ),
+                    startY = 0f,
+                    endY = 1000f
+                )
+            ),
         contentAlignment = Alignment.Center
     ) {
-        Column(horizontalAlignment = Alignment.CenterHorizontally) {
-            Text(message)
-            Spacer(Modifier.height(16.dp))
-            Button(onClick = onRetry) {
-                Text("다시 시도")
-            }
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Paddings.large)
+        ) {
+            Icon(
+                imageVector = Icons.Default.Error,
+                contentDescription = null,
+                tint = MaterialTheme.colorScheme.error,
+                modifier = Modifier.size(64.dp)
+            )
+            Text(
+                text = message,
+                style = MaterialTheme.typography.titleMedium,
+                textAlign = TextAlign.Center
+            )
+            LargeButton(text = "다시 시도", onClick = onRetry)
         }
     }
 }

--- a/presentation/src/main/java/com/example/presentation/splash/screen/LoadingScreen.kt
+++ b/presentation/src/main/java/com/example/presentation/splash/screen/LoadingScreen.kt
@@ -1,18 +1,50 @@
 package com.example.presentation.splash.screen
 
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.unit.dp
+import com.example.presentation.R
+import com.example.presentation.common.theme.GradientNavy
+import com.example.presentation.common.theme.Paddings
 
 @Composable
 fun LoadingScreen() {
     Box(
-        modifier = Modifier.fillMaxSize(),
+        modifier = Modifier
+            .fillMaxSize()
+            .background(
+                brush = Brush.verticalGradient(
+                    colors = listOf(
+                        GradientNavy.copy(alpha = 0f),
+                        GradientNavy.copy(alpha = 1f)
+                    ),
+                    startY = 0f,
+                    endY = 1000f
+                )
+            ),
         contentAlignment = Alignment.Center
     ) {
-        CircularProgressIndicator()
+        Column(
+            horizontalAlignment = Alignment.CenterHorizontally,
+            verticalArrangement = Arrangement.spacedBy(Paddings.extra)
+        ) {
+            Image(
+                painter = painterResource(id = R.drawable.ic_splash_rocket),
+                contentDescription = null,
+                modifier = Modifier.size(120.dp)
+            )
+            CircularProgressIndicator()
+        }
     }
 }


### PR DESCRIPTION
## Summary
- refine splash loading screen with gradient background and rocket
- enhance error screen with themed design and retry button

## Testing
- `./gradlew :presentation:compileDebugKotlin` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68acf86306288325a19bc2c76b51a74b