### PR TITLE
Implement auth remote methods and add tests

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -60,6 +60,8 @@ dependencies {
     implementation(libs.appcompat)
     implementation(libs.material)
     testImplementation(libs.junit)
+    testImplementation(libs.kotlinx.coroutines.test)
+    testImplementation(libs.mockk)
     androidTestImplementation(libs.androidx.test.ext.junit)
     androidTestImplementation(libs.espresso.core)
 

--- a/data/src/main/java/com/example/data/source/remote/impl/AuthRemoteDataSourceImpl.kt
+++ b/data/src/main/java/com/example/data/source/remote/impl/AuthRemoteDataSourceImpl.kt
@@ -137,19 +137,52 @@ class AuthRemoteDataSourceImpl @Inject constructor(
     }
 
     override suspend fun getUserById(userId: String): UserDto? {
-        TODO("Not yet implemented")
+        return try {
+            val snapshot = firestore.collection("users")
+                .document(userId)
+                .get()
+                .await()
+            snapshot.toObject(UserDto::class.java)
+        } catch (e: Exception) {
+            Timber.tag("AuthRemoteDataSourceImpl").e(e, "getUserById failed")
+            throw e
+        }
     }
 
     override suspend fun saveUser(userDto: UserDto) {
-        TODO("Not yet implemented")
+        try {
+            firestore.collection("users")
+                .document(userDto.id)
+                .set(userDto)
+                .await()
+        } catch (e: Exception) {
+            Timber.tag("AuthRemoteDataSourceImpl").e(e, "saveUser failed")
+            throw e
+        }
     }
 
     override suspend fun saveChurch(churchDto: ChurchDto) {
-        TODO("Not yet implemented")
+        try {
+            firestore.collection("churches")
+                .document(churchDto.id)
+                .set(churchDto)
+                .await()
+        } catch (e: Exception) {
+            Timber.tag("AuthRemoteDataSourceImpl").e(e, "saveChurch failed")
+            throw e
+        }
     }
 
     override suspend fun createUser(email: String, password: String): String {
-        TODO("Not yet implemented")
+        return try {
+            val result = firebaseAuth
+                .createUserWithEmailAndPassword(email, password)
+                .await()
+            result.user?.uid ?: throw Exception("User creation failed")
+        } catch (e: Exception) {
+            Timber.tag("AuthRemoteDataSourceImpl").e(e, "createUser failed")
+            throw e
+        }
     }
 
     override suspend fun isLoggedIn(): Boolean {

--- a/data/src/test/java/com/example/data/source/remote/AuthRemoteDataSourceImplTest.kt
+++ b/data/src/test/java/com/example/data/source/remote/AuthRemoteDataSourceImplTest.kt
@@ -1,0 +1,177 @@
+package com.example.data.source.remote
+
+import com.example.data.model.dto.ChurchDto
+import com.example.data.model.dto.UserDto
+import com.example.data.source.remote.impl.AuthRemoteDataSourceImpl
+import com.google.android.gms.tasks.Tasks
+import com.google.firebase.Timestamp
+import com.google.firebase.auth.AuthResult
+import com.google.firebase.auth.FirebaseAuth
+import com.google.firebase.auth.FirebaseUser
+import com.google.firebase.firestore.CollectionReference
+import com.google.firebase.firestore.DocumentReference
+import com.google.firebase.firestore.DocumentSnapshot
+import com.google.firebase.firestore.FirebaseFirestore
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import kotlinx.coroutines.test.runTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.fail
+import org.junit.Test
+
+class AuthRemoteDataSourceImplTest {
+
+    private val firebaseAuth: FirebaseAuth = mockk(relaxed = true)
+    private val firestore: FirebaseFirestore = mockk()
+    private val dataSource = AuthRemoteDataSourceImpl(firebaseAuth, firestore)
+
+    @Test
+    fun getUserById_success_returnsUser() = runTest {
+        val user = UserDto(id = "123", email = "e", name = "n", role = "r", churchId = "c")
+        val collection = mockk<CollectionReference>()
+        val document = mockk<DocumentReference>()
+        val snapshot = mockk<DocumentSnapshot>()
+
+        every { firestore.collection("users") } returns collection
+        every { collection.document("123") } returns document
+        every { document.get() } returns Tasks.forResult(snapshot)
+        every { snapshot.toObject(UserDto::class.java) } returns user
+
+        val result = dataSource.getUserById("123")
+        assertEquals(user, result)
+    }
+
+    @Test
+    fun getUserById_failure_throwsException() = runTest {
+        val collection = mockk<CollectionReference>()
+        val document = mockk<DocumentReference>()
+        val exception = Exception("network")
+
+        every { firestore.collection("users") } returns collection
+        every { collection.document("123") } returns document
+        every { document.get() } returns Tasks.forException(exception)
+
+        try {
+            dataSource.getUserById("123")
+            fail("Exception expected")
+        } catch (e: Exception) {
+            assertEquals("network", e.message)
+        }
+    }
+
+    @Test
+    fun saveUser_success_writesDocument() = runTest {
+        val user = UserDto(id = "123", email = "", name = "", role = "", churchId = "")
+        val collection = mockk<CollectionReference>()
+        val document = mockk<DocumentReference>()
+
+        every { firestore.collection("users") } returns collection
+        every { collection.document("123") } returns document
+        every { document.set(user) } returns Tasks.forResult(null)
+
+        dataSource.saveUser(user)
+        verify { document.set(user) }
+    }
+
+    @Test
+    fun saveUser_failure_throwsException() = runTest {
+        val user = UserDto(id = "123", email = "", name = "", role = "", churchId = "")
+        val collection = mockk<CollectionReference>()
+        val document = mockk<DocumentReference>()
+        val exception = Exception("write")
+
+        every { firestore.collection("users") } returns collection
+        every { collection.document("123") } returns document
+        every { document.set(user) } returns Tasks.forException(exception)
+
+        try {
+            dataSource.saveUser(user)
+            fail("Exception expected")
+        } catch (e: Exception) {
+            assertEquals("write", e.message)
+        }
+    }
+
+    @Test
+    fun saveChurch_success_writesDocument() = runTest {
+        val church = ChurchDto(
+            id = "c1",
+            name = "n",
+            profileImageUrl = null,
+            region = "r",
+            phone = "p",
+            description = "d",
+            createdAt = Timestamp.now(),
+            adminId = "a",
+            adminName = "an",
+            adminPosition = "ap"
+        )
+        val collection = mockk<CollectionReference>()
+        val document = mockk<DocumentReference>()
+
+        every { firestore.collection("churches") } returns collection
+        every { collection.document("c1") } returns document
+        every { document.set(church) } returns Tasks.forResult(null)
+
+        dataSource.saveChurch(church)
+        verify { document.set(church) }
+    }
+
+    @Test
+    fun saveChurch_failure_throwsException() = runTest {
+        val church = ChurchDto(
+            id = "c1",
+            name = "n",
+            profileImageUrl = null,
+            region = "r",
+            phone = "p",
+            description = "d",
+            createdAt = Timestamp.now(),
+            adminId = "a",
+            adminName = "an",
+            adminPosition = "ap"
+        )
+        val collection = mockk<CollectionReference>()
+        val document = mockk<DocumentReference>()
+        val exception = Exception("fail")
+
+        every { firestore.collection("churches") } returns collection
+        every { collection.document("c1") } returns document
+        every { document.set(church) } returns Tasks.forException(exception)
+
+        try {
+            dataSource.saveChurch(church)
+            fail("Exception expected")
+        } catch (e: Exception) {
+            assertEquals("fail", e.message)
+        }
+    }
+
+    @Test
+    fun createUser_success_returnsUid() = runTest {
+        val authResult = mockk<AuthResult>()
+        val user = mockk<FirebaseUser>()
+
+        every { firebaseAuth.createUserWithEmailAndPassword("e", "p") } returns Tasks.forResult(authResult)
+        every { authResult.user } returns user
+        every { user.uid } returns "uid123"
+
+        val uid = dataSource.createUser("e", "p")
+        assertEquals("uid123", uid)
+    }
+
+    @Test
+    fun createUser_failure_throwsException() = runTest {
+        val exception = Exception("create")
+        every { firebaseAuth.createUserWithEmailAndPassword("e", "p") } returns Tasks.forException(exception)
+
+        try {
+            dataSource.createUser("e", "p")
+            fail("Exception expected")
+        } catch (e: Exception) {
+            assertEquals("create", e.message)
+        }
+    }
+}
+

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,7 @@ orbit = "6.1.0"
 coil = "2.3.0"
 paging = "3.2.1"
 coroutines-core = "1.7.3"
+mockk = "1.13.9"
 room = "2.6.1"
 firebase-bom = "32.7.0"
 protobuf-lite = "3.23.4"
@@ -68,6 +69,8 @@ paging-runtime = { group = "androidx.paging", name = "paging-runtime", version.r
 paging-common = { group = "androidx.paging", name = "paging-common", version.ref = "paging" }
 paging-compose = { group = "androidx.paging", name = "paging-compose", version.ref = "paging" }
 coroutines-core = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-core", version.ref = "coroutines-core" }
+kotlinx-coroutines-test = { group = "org.jetbrains.kotlinx", name = "kotlinx-coroutines-test", version.ref = "coroutines-core" }
+mockk = { group = "io.mockk", name = "mockk", version.ref = "mockk" }
 room-runtime = { group = "androidx.room", name = "room-runtime", version.ref = "room" }
 room-ktx = { group = "androidx.room", name = "room-ktx", version.ref = "room" }
 room-compiler = { group = "androidx.room", name = "room-compiler", version.ref = "room" }


### PR DESCRIPTION
## Summary
- implement user/church persistence and account creation in AuthRemoteDataSourceImpl
- add unit tests covering success and failure cases
- add test dependencies for coroutines and mockk

## Testing
- `./gradlew :data:test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0160e01a4832589f87dc35ed56378