### PR TITLE
Use unspecified role as default

### DIFF
--- a/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
+++ b/data/src/main/java/com/example/data/repository/AuthRepositoryImpl.kt
@@ -32,7 +32,7 @@ class AuthRepositoryImpl @Inject constructor(
     }
 
     override suspend fun getCurrentUserRole(): UserRole {
-        val roleProto = userPreferences.userRole.firstOrNull() ?: UserRoleProto.GUEST
+        val roleProto = userPreferences.userRole.firstOrNull() ?: UserRoleProto.USER_ROLE_UNSPECIFIED
         val role = roleProto.toDomain()
         Timber.tag("AuthRepositoryImpl").d("getCurrentUserRole: $role")
         return role


### PR DESCRIPTION
## Summary
- use `USER_ROLE_UNSPECIFIED` as the fallback user role

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b0160b683c832596b47c985ae8c0fd