### PR TITLE
Configure backup and transfer data rules

### DIFF
--- a/app/src/main/res/xml/data_extraction_rules.xml
+++ b/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,19 +1,16 @@
-<?xml version="1.0" encoding="utf-8"?><!--
-   Sample data extraction rules file; uncomment and customize as necessary.
-   See https://developer.android.com/about/versions/12/backup-restore#xml-changes
-   for details.
--->
+<?xml version="1.0" encoding="utf-8"?>
 <data-extraction-rules>
     <cloud-backup>
-        <!-- TODO: Use <include> and <exclude> to control what is backed up.
-        <include .../>
-        <exclude .../>
-        -->
+        <!-- Include only non-sensitive databases and exclude personal or sensitive data -->
+        <include domain="database" path="app_database"/>
+        <exclude domain="file" path="datastore/user_prefs.pb"/>
+        <exclude domain="sharedpref" path="."/>
     </cloud-backup>
-    <!--
     <device-transfer>
-        <include .../>
-        <exclude .../>
+        <!-- Transfer necessary database content while omitting sensitive data -->
+        <include domain="database" path="app_database"/>
+        <exclude domain="file" path="datastore/user_prefs.pb"/>
+        <exclude domain="sharedpref" path="."/>
     </device-transfer>
-    -->
 </data-extraction-rules>
+


### PR DESCRIPTION
## Summary
- specify cloud backup and device transfer data-extraction rules
- exclude user preferences and shared preferences from backups while including database

## Testing
- `./gradlew lint` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b10269dd688325a710e17531272e25