### PR TITLE
Integrate view model refresh logic into MemberNavHost

### DIFF
--- a/presentation/src/main/java/com/example/presentation/member/screen/MemberNavHost.kt
+++ b/presentation/src/main/java/com/example/presentation/member/screen/MemberNavHost.kt
@@ -36,6 +36,7 @@ import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.saveable.rememberSaveable
 import androidx.compose.runtime.setValue
+import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Offset
 import androidx.compose.ui.graphics.Color
@@ -71,6 +72,9 @@ import com.example.presentation.shared.feature.user.screen.UserScreen
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlin.math.max
+import android.widget.Toast
+import timber.log.Timber
+import com.example.presentation.member.screen.home.HomeViewModel
 
 @SuppressLint("UnusedMaterial3ScaffoldPaddingParameter")
 @Composable
@@ -107,6 +111,7 @@ fun MemberNavHost(onNavigateToPostWrite: (Context) -> Unit) {
     val refreshHoldMillis = 1200L
     var refreshing by remember { mutableStateOf(false) }
     val scope = rememberCoroutineScope()
+    val homeViewModel: HomeViewModel = hiltViewModel()
 
     var isScrollingDown by remember { mutableStateOf(false) }
     var targetScrollingDown by remember { mutableStateOf(false) }
@@ -170,7 +175,11 @@ fun MemberNavHost(onNavigateToPostWrite: (Context) -> Unit) {
                     refreshing = true
                     pullOffsetPx = 0f
                     scope.launch {
-                        // TODO: 실제 새로고침 로직 호출
+                        homeViewModel.refresh()
+                            .onFailure { e ->
+                                Timber.e(e, "Home refresh failed")
+                                Toast.makeText(context, "새로고침 실패", Toast.LENGTH_SHORT).show()
+                            }
                         delay(refreshHoldMillis)
                         refreshing = false
                     }

--- a/presentation/src/main/java/com/example/presentation/member/screen/home/HomeViewModel.kt
+++ b/presentation/src/main/java/com/example/presentation/member/screen/home/HomeViewModel.kt
@@ -1,0 +1,26 @@
+package com.example.presentation.member.screen.home
+
+import androidx.lifecycle.ViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import kotlinx.coroutines.delay
+import javax.inject.Inject
+
+/**
+ * ViewModel responsible for handling refresh logic on the member home screen.
+ * Currently contains a placeholder refresh implementation which should be
+ * replaced with real data fetching logic.
+ */
+@HiltViewModel
+class HomeViewModel @Inject constructor() : ViewModel() {
+
+    /**
+     * Refreshes home data.
+     *
+     * @return [Result] representing success or failure of the refresh action.
+     */
+    suspend fun refresh(): Result<Unit> = runCatching {
+        // Placeholder for actual refresh logic
+        delay(500)
+    }
+}
+


### PR DESCRIPTION
## Summary
- Use `HomeViewModel` to drive pull-to-refresh in `MemberNavHost`
- Handle refresh success and failure to update refreshing state and show errors
- Introduce `HomeViewModel` with placeholder refresh method

## Testing
- `./gradlew test` *(fails: SDK location not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b1026ac1248325b432a5d23575cbfb